### PR TITLE
Add developer docs and agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Guidelines
+
+This repository uses automated agents to assist with development tasks. Please follow these rules when contributing via an agent:
+
+1. **Run checks** – Before opening a pull request, run `poe check` if dependencies are available. This runs formatting, linting and tests.
+2. **Testing limitations** – If checks fail because required dependencies cannot be installed, note this in your PR description.
+3. **Documentation** – Add or update markdown files in the `docs/` folder when making significant changes.
+4. **Style** – Keep lines under 120 characters and prefer descriptive commit messages.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Magentic-UI Documentation
+
+This folder collects additional developer documentation for Magentic-UI. It supplements the main `README.md` with technical details about the project structure and tips for making contributions.
+
+- [Code Overview](code_overview.md)
+- [Editing Guide](editing-guide.md)
+

--- a/docs/code_overview.md
+++ b/docs/code_overview.md
@@ -1,0 +1,24 @@
+# Code Overview
+
+This document describes the main components of Magentic-UI so contributors can navigate the codebase more easily.
+
+## Python Package
+
+The Python source code lives under `src/magentic_ui`.
+
+- `agents/` – definitions for the different agents (e.g. **Orchestrator**, **WebSurfer**, **Coder**, **FileSurfer**, and **UserProxy**).
+- `backend/` – FastAPI backend that powers the web interface.
+- `tools/` – helper utilities used by the agents. For example, browser automation utilities live in `tools/playwright`.
+- `eval/` – scripts and utilities for running benchmarks.
+- `task_team.py` and related modules – entry points for constructing agent teams.
+
+Import the library via `import magentic_ui` or run the CLI with `magentic ui`.
+
+## Frontend
+
+The frontend is a [Gatsby](https://www.gatsbyjs.com/) application located in the `frontend/` directory. Source files are under `frontend/src`. The `package.json` there describes JavaScript dependencies.
+
+## Tests
+
+Unit tests reside in the `tests/` directory and can be executed with `pytest`. Some tests rely on `playwright`, which may require downloading browser binaries. See the [Editing Guide](editing-guide.md) for tips on running tests locally.
+

--- a/docs/editing-guide.md
+++ b/docs/editing-guide.md
@@ -1,0 +1,29 @@
+# Editing Guide
+
+This guide highlights common tasks for modifying Magentic-UI.
+
+## Setting Up a Development Environment
+
+1. Install the project with development dependencies:
+   ```bash
+   pip install -e .[dev]
+   ```
+2. Install Playwright browsers (needed for some tests):
+   ```bash
+   playwright install
+   ```
+
+## Running Checks
+
+Use `poe check` to run formatting, linting and the test suite:
+
+```bash
+poe check
+```
+
+Some tests require Playwright browsers and may take time to run. If dependencies are missing, install them as shown above.
+
+## Updating Documentation
+
+Markdown documentation lives in the `docs/` folder. Keep documents concise and make sure to reference images using relative paths.
+


### PR DESCRIPTION
## Summary
- add a docs directory with developer documentation
- provide instructions for editing the project
- document an overview of the code structure
- add AGENTS.md with basic rules for future agents

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684085298c90832aa519844b7e31e679