### PR TITLE
Implement browser port retry for headless mode

### DIFF
--- a/src/magentic_ui/tools/playwright/browser/headless_docker_playwright_browser.py
+++ b/src/magentic_ui/tools/playwright/browser/headless_docker_playwright_browser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from .utils import get_available_port
 
 from autogen_core import Component
 import docker
@@ -75,8 +76,14 @@ class HeadlessDockerPlaywrightBrowser(
         """
         Generate a new address for the Playwright browser. Used if the current address fails to connect.
         """
-        # TODO: Implement this
-        pass
+        port, sock = get_available_port()
+        self._playwright_port = port
+        self._hostname = (
+            f"magentic-ui-headless-browser_{self._playwright_port}"
+            if self._inside_docker
+            else "localhost"
+        )
+        sock.close()
 
     async def create_container(self) -> Container:
         """


### PR DESCRIPTION
## Summary
- generate a new port when the headless Playwright browser fails to start
- hook into existing retry logic by updating `_playwright_port` and `_hostname`

## Testing
- `poe check`

------
https://chatgpt.com/codex/tasks/task_e_684088e8e744832a989cf69043fa105c