### PR TITLE
Fix type hints in samples and tests

### DIFF
--- a/samples/sample_azure_agent.py
+++ b/samples/sample_azure_agent.py
@@ -40,6 +40,7 @@ async def azure_agent_example():
     async with AIProjectClient.from_connection_string(  # type: ignore
         credential=credential, conn_str=os.getenv("AI_PROJECT_CONNECTION_STRING", "")
     ) as project_client:
+        project_client: AIProjectClient
         azure_agent = AzureAIAgent(
             name="azure_agent",
             description="An AI assistant",
@@ -92,9 +93,9 @@ async def get_task_team_with_azure_agent(
         return ChatCompletionClient.load_component(model_client_config)
 
     if not magentic_ui_config.inside_docker:
-        assert (
-            paths.external_run_dir == paths.internal_run_dir
-        ), "External and internal run dirs must be the same in non-docker mode"
+        assert paths.external_run_dir == paths.internal_run_dir, (
+            "External and internal run dirs must be the same in non-docker mode"
+        )
 
     model_client_orch = get_model_client(
         magentic_ui_config.model_client_configs.orchestrator
@@ -163,15 +164,15 @@ async def get_task_team_with_azure_agent(
     if magentic_ui_config.user_proxy_type == "dummy":
         user_proxy = DummyUserProxy(name="user_proxy")
     elif magentic_ui_config.user_proxy_type == "metadata":
-        assert (
-            magentic_ui_config.task is not None
-        ), "Task must be provided for metadata user proxy"
-        assert (
-            magentic_ui_config.hints is not None
-        ), "Hints must be provided for metadata user proxy"
-        assert (
-            magentic_ui_config.answer is not None
-        ), "Answer must be provided for metadata user proxy"
+        assert magentic_ui_config.task is not None, (
+            "Task must be provided for metadata user proxy"
+        )
+        assert magentic_ui_config.hints is not None, (
+            "Hints must be provided for metadata user proxy"
+        )
+        assert magentic_ui_config.answer is not None, (
+            "Answer must be provided for metadata user proxy"
+        )
         user_proxy = MetadataUserProxy(
             name="user_proxy",
             description="Metadata User Proxy Agent",
@@ -262,6 +263,7 @@ async def get_task_team_with_azure_agent(
     async with AIProjectClient.from_connection_string(  # type: ignore
         credential=credential, conn_str=os.getenv("AI_PROJECT_CONNECTION_STRING", "")
     ) as project_client:
+        project_client: AIProjectClient
         azure_reasoning_agent = AzureAIAgent(
             name="azure_reasoning_agent",
             description="An AI assistant that can help with complex math and logic tasks",

--- a/tests/test_playwright_state.py
+++ b/tests/test_playwright_state.py
@@ -1,7 +1,7 @@
 import pytest
 import pytest_asyncio
 from typing import AsyncGenerator
-from playwright.async_api import Browser, BrowserContext, async_playwright
+from playwright.async_api import Browser, BrowserContext, Page, async_playwright
 from magentic_ui.tools.playwright.playwright_state import (
     BrowserState,
     Tab,
@@ -32,7 +32,7 @@ async def multi_tab_context(
     browser_context: BrowserContext,
 ) -> AsyncGenerator[BrowserContext, None]:
     # Create multiple tabs with different URLs and scroll positions
-    pages = []
+    pages: list[Page] = []
     urls = [
         "data:text/html,<body style='height: 2000px'>Page 1</body>",
         "data:text/html,<body style='height: 2000px'>Page 2</body>",
@@ -40,7 +40,7 @@ async def multi_tab_context(
     ]
 
     for url in urls:
-        page = await browser_context.new_page()
+        page: Page = await browser_context.new_page()
         await page.goto(url)
         await page.evaluate("window.scrollTo(0, 100)")
         pages.append(page)
@@ -54,7 +54,7 @@ async def multi_tab_context(
 @pytest.mark.asyncio
 async def test_save_state_basic(browser_context: BrowserContext):
     """Test saving state with a single tab"""
-    page = await browser_context.new_page()
+    page: Page = await browser_context.new_page()
     url = "data:text/html,<body>Test Page</body>"
     await page.goto(url)
 
@@ -71,7 +71,7 @@ async def test_save_state_basic(browser_context: BrowserContext):
 @pytest.mark.asyncio
 async def test_save_state_with_scroll(browser_context: BrowserContext):
     """Test saving state with scroll position"""
-    page = await browser_context.new_page()
+    page: Page = await browser_context.new_page()
     url = "data:text/html,<body style='height: 2000px'>Test Page</body>"
     await page.goto(url)
     await page.evaluate("window.scrollTo(0, 100)")


### PR DESCRIPTION
## Summary
- annotate AIProjectClient variable in sample Azure agent
- type Page objects in Playwright state tests

## Testing
- `poe check` *(fails: Sequence aborted after failed subtask 'pyright')*

------
https://chatgpt.com/codex/tasks/task_e_6840901e8e50832a8c68246ba6c1834c