### PR TITLE
Add pause/resume events

### DIFF
--- a/src/magentic_ui/agents/_coder.py
+++ b/src/magentic_ui/agents/_coder.py
@@ -441,15 +441,21 @@ class CoderAgent(BaseChatAgent, Component[CoderAgentConfig]):
         # Close the model client.
         await self._model_client.close()
 
-    async def pause(self) -> None:
+    async def on_pause(self, cancellation_token: CancellationToken) -> None:
         """Pause the agent by setting the paused state."""
         self.is_paused = True
         self._paused.set()
 
-    async def resume(self) -> None:
+    async def on_resume(self, cancellation_token: CancellationToken) -> None:
         """Resume the agent by clearing the paused state."""
         self.is_paused = False
         self._paused.clear()
+
+    async def pause(self) -> None:
+        await self.on_pause(CancellationToken())
+
+    async def resume(self) -> None:
+        await self.on_resume(CancellationToken())
 
     @property
     def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:

--- a/src/magentic_ui/agents/file_surfer/_file_surfer.py
+++ b/src/magentic_ui/agents/file_surfer/_file_surfer.py
@@ -176,15 +176,21 @@ class FileSurfer(BaseChatAgent, Component[FileSurferConfig]):
             await self._browser.lazy_init()
             self.did_lazy_init = True
 
-    async def pause(self) -> None:
+    async def on_pause(self, cancellation_token: CancellationToken) -> None:
         """Pause the FileSurfer agent."""
         self.is_paused = True
         self._pause_event.set()
 
-    async def resume(self) -> None:
+    async def on_resume(self, cancellation_token: CancellationToken) -> None:
         """Resume the FileSurfer agent."""
         self.is_paused = False
         self._pause_event.clear()
+
+    async def pause(self) -> None:
+        await self.on_pause(CancellationToken())
+
+    async def resume(self) -> None:
+        await self.on_resume(CancellationToken())
 
     @property
     def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
@@ -586,7 +592,7 @@ class FileSurfer(BaseChatAgent, Component[FileSurferConfig]):
         current_page = self._browser.viewport_current_page
         total_pages = len(self._browser.viewport_pages)
         header += (
-            f" Viewport position: Showing page {current_page+1} of {total_pages}.\n"
+            f" Viewport position: Showing page {current_page + 1} of {total_pages}.\n"
         )
 
         return (header, self._browser.viewport)

--- a/src/magentic_ui/agents/web_surfer/_web_surfer.py
+++ b/src/magentic_ui/agents/web_surfer/_web_surfer.py
@@ -416,7 +416,7 @@ class WebSurfer(BaseChatAgent, Component[WebSurferConfig]):
         await self._set_debug_dir()
         self.did_lazy_init = True
 
-    async def pause(self) -> None:
+    async def on_pause(self, cancellation_token: CancellationToken) -> None:
         """Pause the WebSurfer agent."""
         self.is_paused = True
         self._pause_event.set()
@@ -426,10 +426,16 @@ class WebSurfer(BaseChatAgent, Component[WebSurferConfig]):
         await self._pause_event.wait()
         cancellation_token.cancel()
 
-    async def resume(self) -> None:
+    async def on_resume(self, cancellation_token: CancellationToken) -> None:
         """Resume the WebSurfer agent."""
         self.is_paused = False
         self._pause_event.clear()
+
+    async def pause(self) -> None:
+        await self.on_pause(CancellationToken())
+
+    async def resume(self) -> None:
+        await self.on_resume(CancellationToken())
 
     async def close(self) -> None:
         """

--- a/src/magentic_ui/teams/orchestrator/__init__.py
+++ b/src/magentic_ui/teams/orchestrator/__init__.py
@@ -1,3 +1,4 @@
 from ._group_chat import GroupChat
+from ._events import GroupChatPause, GroupChatResume
 
-__all__ = ["GroupChat"]
+__all__ = ["GroupChat", "GroupChatPause", "GroupChatResume"]

--- a/src/magentic_ui/teams/orchestrator/_events.py
+++ b/src/magentic_ui/teams/orchestrator/_events.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class GroupChatPause(BaseModel):
+    """Event to pause the group chat."""
+
+    ...
+
+
+class GroupChatResume(BaseModel):
+    """Event to resume the group chat."""
+
+    ...

--- a/src/magentic_ui/teams/orchestrator/_group_chat.py
+++ b/src/magentic_ui/teams/orchestrator/_group_chat.py
@@ -127,25 +127,13 @@ class GroupChat(BaseGroupChat, Component[GroupChatConfig]):
                 source="orchestrator", state=json.dumps(partial_state)
             )  # type: ignore
 
-    async def pause(self) -> None:  # TODO: can this be implemented using events?
-        orchestrator = await self._runtime.try_get_underlying_agent_instance(
-            AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
-            type=Orchestrator,
-        )
-        await orchestrator.pause()
-        for agent in self._participants:
-            if hasattr(agent, "pause"):
-                await agent.pause()  # type: ignore
+    async def pause(self) -> None:
+        """Pause the team via events."""
+        await super().pause()
 
     async def resume(self) -> None:
-        orchestrator = await self._runtime.try_get_underlying_agent_instance(
-            AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
-            type=Orchestrator,
-        )
-        await orchestrator.resume()
-        for agent in self._participants:
-            if hasattr(agent, "resume"):
-                await agent.resume()  # type: ignore
+        """Resume the team via events."""
+        await super().resume()
 
     async def lazy_init(self) -> None:
         await asyncio.gather(

--- a/src/magentic_ui/teams/orchestrator/_orchestrator.py
+++ b/src/magentic_ui/teams/orchestrator/_orchestrator.py
@@ -36,6 +36,7 @@ from autogen_agentchat.teams._group_chat._events import (
     GroupChatStart,
     GroupChatTermination,
 )
+from ._events import GroupChatPause, GroupChatResume
 from autogen_agentchat.teams._group_chat._base_group_chat_manager import (
     BaseGroupChatManager,
 )
@@ -493,6 +494,18 @@ class Orchestrator(BaseGroupChatManager):
 
     async def resume(self) -> None:
         """Resume the group chat manager."""
+        self._state.is_paused = False
+
+    @rpc
+    async def handle_pause(self, message: GroupChatPause, ctx: MessageContext) -> None:  # type: ignore
+        """Handle a pause event."""
+        self._state.is_paused = True
+
+    @rpc
+    async def handle_resume(
+        self, message: GroupChatResume, ctx: MessageContext
+    ) -> None:  # type: ignore
+        """Handle a resume event."""
         self._state.is_paused = False
 
     @event
@@ -1100,7 +1113,10 @@ class Orchestrator(BaseGroupChatManager):
             else []
         )
         completed_plan_str = "\n".join(
-            [f"COMPLETED STEP {i+1}: {step}" for i, step in enumerate(completed_steps)]
+            [
+                f"COMPLETED STEP {i + 1}: {step}"
+                for i, step in enumerate(completed_steps)
+            ]
         )
 
         # Add completed steps info to replan prompt

--- a/tests/test_group_chat_pause_resume.py
+++ b/tests/test_group_chat_pause_resume.py
@@ -1,0 +1,95 @@
+import asyncio
+import pytest
+from pydantic import BaseModel
+from autogen_core.models._model_client import ChatCompletionClient
+from autogen_core.models._types import CreateResult, RequestUsage
+from autogen_core import AgentId, CancellationToken
+from autogen_agentchat.agents import BaseChatAgent
+from autogen_agentchat.base import Response
+from autogen_agentchat.messages import TextMessage
+
+from magentic_ui.teams.orchestrator import GroupChat
+from magentic_ui.teams.orchestrator._orchestrator import Orchestrator
+from magentic_ui.teams.orchestrator.orchestrator_config import OrchestratorConfig
+
+
+class DummyModelConfig(BaseModel):
+    pass
+
+
+class DummyChatCompletionClient(ChatCompletionClient):
+    component_config_schema = DummyModelConfig
+    component_provider_override = "tests.DummyChatCompletionClient"
+
+    async def create(
+        self,
+        messages,
+        *,
+        tools=[],
+        json_output=None,
+        extra_create_args={},
+        cancellation_token=None,
+    ):
+        return CreateResult(
+            finish_reason="stop",
+            content="",
+            usage=RequestUsage(0, 0),
+            cached=False,
+        )
+
+    def _to_config(self) -> DummyModelConfig:  # type: ignore[override]
+        return DummyModelConfig()
+
+    @classmethod
+    def _from_config(cls, config: DummyModelConfig) -> "DummyChatCompletionClient":  # type: ignore[override]
+        return cls()
+
+    async def close(self) -> None:
+        pass
+
+
+class SimpleAgent(BaseChatAgent):
+    def __init__(self, name: str):
+        super().__init__(name, "simple agent")
+        self.paused = False
+
+    @property
+    def produced_message_types(self):
+        return (TextMessage,)
+
+    async def on_messages(self, messages, cancellation_token: CancellationToken):
+        return Response(chat_message=TextMessage(content="ok", source=self.name))
+
+    async def on_pause(self, cancellation_token: CancellationToken) -> None:
+        self.paused = True
+
+    async def on_resume(self, cancellation_token: CancellationToken) -> None:
+        self.paused = False
+
+
+@pytest.mark.asyncio
+async def test_pause_resume_events():
+    agent1 = SimpleAgent("assistant")
+    user = SimpleAgent("user_proxy")
+    model_client = DummyChatCompletionClient()
+    gc = GroupChat(
+        participants=[agent1, user],
+        model_client=model_client,
+        orchestrator_config=OrchestratorConfig(),
+    )
+    runtime = gc._runtime
+    runtime.start()
+    await gc._init(runtime)
+    await gc.pause()
+    await asyncio.sleep(0.05)
+    orchestrator = await runtime.try_get_underlying_agent_instance(
+        AgentId(type=gc._group_chat_manager_topic_type, key=gc._team_id),
+        type=Orchestrator,
+    )
+    assert agent1.paused
+    assert orchestrator._state.is_paused
+    await gc.resume()
+    await asyncio.sleep(0.05)
+    assert not agent1.paused
+    assert not orchestrator._state.is_paused
+    runtime.stop()


### PR DESCRIPTION
## Summary
- define `GroupChatPause` and `GroupChatResume` events
- update `GroupChat` to emit pause/resume events
- handle pause/resume in `Orchestrator`
- implement pause/resume hooks in agents
- test pause/resume flow

## Testing
- `ruff format src tests`
- `ruff check src tests`
- `pyright src` *(fails: Import "tldextract" could not be resolved)*
- `PYTHONPATH=src pytest tests/test_group_chat_pause_resume.py -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_6840900194a8832aabb3fc31292a3989