### PR TITLE
Fix pause/resume event typing

### DIFF
--- a/src/magentic_ui/teams/orchestrator/_events.py
+++ b/src/magentic_ui/teams/orchestrator/_events.py
@@ -1,13 +1,13 @@
-from pydantic import BaseModel
+"""Events used by the orchestrator team implementation."""
 
+# Re-export the base group chat events so that our orchestrator inherits the
+# exact same types as :class:`autogen_agentchat.teams.BaseGroupChatManager`.
+# This avoids typing mismatches when overriding methods that handle these
+# events.
 
-class GroupChatPause(BaseModel):
-    """Event to pause the group chat."""
+from autogen_agentchat.teams._group_chat._events import (
+    GroupChatPause,
+    GroupChatResume,
+)
 
-    ...
-
-
-class GroupChatResume(BaseModel):
-    """Event to resume the group chat."""
-
-    ...
+__all__ = ["GroupChatPause", "GroupChatResume"]

--- a/tests/test_group_chat_pause_resume.py
+++ b/tests/test_group_chat_pause_resume.py
@@ -37,6 +37,25 @@ class DummyChatCompletionClient(ChatCompletionClient):
             cached=False,
         )
 
+    async def create_stream(
+        self,
+        messages,
+        *,
+        tools=[],
+        json_output=None,
+        extra_create_args={},
+        cancellation_token=None,
+    ):
+        if False:
+            yield
+        yield ""
+        yield CreateResult(
+            finish_reason="stop",
+            content="",
+            usage=RequestUsage(0, 0),
+            cached=False,
+        )
+
     def _to_config(self) -> DummyModelConfig:  # type: ignore[override]
         return DummyModelConfig()
 
@@ -46,6 +65,26 @@ class DummyChatCompletionClient(ChatCompletionClient):
 
     async def close(self) -> None:
         pass
+
+    def actual_usage(self) -> RequestUsage:
+        return RequestUsage(0, 0)
+
+    def total_usage(self) -> RequestUsage:
+        return RequestUsage(0, 0)
+
+    def count_tokens(self, messages, *, tools=[]):
+        return 0
+
+    def remaining_tokens(self, messages, *, tools=[]):
+        return 0
+
+    @property
+    def capabilities(self):
+        return {}
+
+    @property
+    def model_info(self):
+        return {}
 
 
 class SimpleAgent(BaseChatAgent):
@@ -65,6 +104,10 @@ class SimpleAgent(BaseChatAgent):
 
     async def on_resume(self, cancellation_token: CancellationToken) -> None:
         self.paused = False
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        """Reset agent state; no-op for tests."""
+        pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- align orchestrator pause/resume events with autogen types
- update dummy classes in tests to satisfy latest interfaces

## Testing
- `poe check`

------
https://chatgpt.com/codex/tasks/task_e_684287c98d98832a98e3c6c8cee50aab