### PR TITLE
Implement explicit block list for URLs

### DIFF
--- a/docs/code_overview.md
+++ b/docs/code_overview.md
@@ -8,7 +8,7 @@ The Python source code lives under `src/magentic_ui`.
 
 - `agents/` – definitions for the different agents (e.g. **Orchestrator**, **WebSurfer**, **Coder**, **FileSurfer**, and **UserProxy**).
 - `backend/` – FastAPI backend that powers the web interface.
-- `tools/` – helper utilities used by the agents. For example, browser automation utilities live in `tools/playwright`.
+ - `tools/` – helper utilities used by the agents. For example, browser automation utilities live in `tools/playwright`. The `UrlStatusManager` here maintains allowed/rejected URL patterns along with an explicit block list for quick denies.
 - `eval/` – scripts and utilities for running benchmarks.
 - `task_team.py` and related modules – entry points for constructing agent teams.
 

--- a/samples/sample_azure_agent.py
+++ b/samples/sample_azure_agent.py
@@ -92,9 +92,9 @@ async def get_task_team_with_azure_agent(
         return ChatCompletionClient.load_component(model_client_config)
 
     if not magentic_ui_config.inside_docker:
-        assert (
-            paths.external_run_dir == paths.internal_run_dir
-        ), "External and internal run dirs must be the same in non-docker mode"
+        assert paths.external_run_dir == paths.internal_run_dir, (
+            "External and internal run dirs must be the same in non-docker mode"
+        )
 
     model_client_orch = get_model_client(
         magentic_ui_config.model_client_configs.orchestrator
@@ -148,7 +148,7 @@ async def get_task_team_with_azure_agent(
         url_statuses={key: "allowed" for key in orchestrator_config.allowed_websites}
         if orchestrator_config.allowed_websites
         else None,
-        url_block_list=get_internal_urls(magentic_ui_config.inside_docker, paths),
+        explicit_block_list=get_internal_urls(magentic_ui_config.inside_docker, paths),
         multiple_tools_per_call=magentic_ui_config.multiple_tools_per_call,
         downloads_folder=str(paths.internal_run_dir),
         debug_dir=str(paths.internal_run_dir),
@@ -163,15 +163,15 @@ async def get_task_team_with_azure_agent(
     if magentic_ui_config.user_proxy_type == "dummy":
         user_proxy = DummyUserProxy(name="user_proxy")
     elif magentic_ui_config.user_proxy_type == "metadata":
-        assert (
-            magentic_ui_config.task is not None
-        ), "Task must be provided for metadata user proxy"
-        assert (
-            magentic_ui_config.hints is not None
-        ), "Hints must be provided for metadata user proxy"
-        assert (
-            magentic_ui_config.answer is not None
-        ), "Answer must be provided for metadata user proxy"
+        assert magentic_ui_config.task is not None, (
+            "Task must be provided for metadata user proxy"
+        )
+        assert magentic_ui_config.hints is not None, (
+            "Hints must be provided for metadata user proxy"
+        )
+        assert magentic_ui_config.answer is not None, (
+            "Answer must be provided for metadata user proxy"
+        )
         user_proxy = MetadataUserProxy(
             name="user_proxy",
             description="Metadata User Proxy Agent",

--- a/src/magentic_ui/agents/web_surfer/_web_surfer.py
+++ b/src/magentic_ui/agents/web_surfer/_web_surfer.py
@@ -130,7 +130,7 @@ class WebSurferConfig(BaseModel):
     max_actions_per_step: int = 5
     to_resize_viewport: bool = True
     url_statuses: Dict[str, UrlStatus] | None = None
-    url_block_list: List[str] | None = None
+    explicit_block_list: List[str] | None = Field(default=None, alias="url_block_list")
     single_tab_mode: bool = False
     json_model_output: bool = False
     multiple_tools_per_call: bool = False
@@ -189,7 +189,7 @@ class WebSurfer(BaseChatAgent, Component[WebSurferConfig]):
         to_resize_viewport (bool, optional): Whether to resize the viewport. Default: True.
         url_statuses (Dict[str, Literal["allowed", "rejected"]], optional): The set of allowed and rejected websites. Default: None.
         single_tab_mode (bool, optional): Whether to use single tab mode. Default: False.
-        url_block_list (List[str], optional): A list of URLs to block. Default: None.
+        explicit_block_list (List[str], optional): A list of URLs to block. Default: None.
         json_model_output (bool, optional): Whether to use JSON output for model_client instead of tool calls. Default: False.
         multiple_tools_per_call (bool, optional): Whether to allow execution of multiple tool calls sequentially per model call. Default: False.
         viewport_height (int, optional): The height of the viewport. Default: 1440.
@@ -243,6 +243,7 @@ class WebSurfer(BaseChatAgent, Component[WebSurferConfig]):
         max_actions_per_step: int = 5,
         to_resize_viewport: bool = True,
         url_statuses: Optional[Dict[str, UrlStatus]] = None,
+        explicit_block_list: Optional[List[str]] = None,
         url_block_list: Optional[List[str]] = None,
         single_tab_mode: bool = False,
         json_model_output: bool = False,
@@ -284,7 +285,8 @@ class WebSurfer(BaseChatAgent, Component[WebSurferConfig]):
         # Call init to set these in case not set
         self._context: BrowserContext | None = None
         self._url_status_manager: UrlStatusManager = UrlStatusManager(
-            url_statuses=url_statuses, url_block_list=url_block_list
+            url_statuses=url_statuses,
+            explicit_block_list=explicit_block_list or url_block_list,
         )
         self._page: Page | None = None
         self._last_download: Download | None = None
@@ -1989,7 +1991,7 @@ class WebSurfer(BaseChatAgent, Component[WebSurferConfig]):
             to_save_screenshots=config.to_save_screenshots,
             to_resize_viewport=config.to_resize_viewport,
             url_statuses=config.url_statuses,
-            url_block_list=config.url_block_list,
+            explicit_block_list=config.explicit_block_list,
             single_tab_mode=config.single_tab_mode,
             json_model_output=config.json_model_output,
             multiple_tools_per_call=config.multiple_tools_per_call,

--- a/src/magentic_ui/backend/teammanager/teammanager.py
+++ b/src/magentic_ui/backend/teammanager/teammanager.py
@@ -73,7 +73,7 @@ class TeamManager:
         if not path.exists():
             raise FileNotFoundError(f"Config file not found: {path}")
 
-        async with aiofiles.open(path) as f:
+        async with aiofiles.open(path, mode="r") as f:  # pyright: ignore[reportUnknownArgumentType,reportUnknownMemberType]
             content = await f.read()
             if path.suffix == ".json":
                 return json.loads(content)

--- a/src/magentic_ui/task_team.py
+++ b/src/magentic_ui/task_team.py
@@ -54,9 +54,9 @@ async def get_task_team(
         return ChatCompletionClient.load_component(model_client_config)
 
     if not magentic_ui_config.inside_docker:
-        assert (
-            paths.external_run_dir == paths.internal_run_dir
-        ), "External and internal run dirs must be the same in non-docker mode"
+        assert paths.external_run_dir == paths.internal_run_dir, (
+            "External and internal run dirs must be the same in non-docker mode"
+        )
 
     model_client_orch = get_model_client(
         magentic_ui_config.model_client_configs.orchestrator
@@ -125,15 +125,15 @@ async def get_task_team(
     if magentic_ui_config.user_proxy_type == "dummy":
         user_proxy = DummyUserProxy(name="user_proxy")
     elif magentic_ui_config.user_proxy_type == "metadata":
-        assert (
-            magentic_ui_config.task is not None
-        ), "Task must be provided for metadata user proxy"
-        assert (
-            magentic_ui_config.hints is not None
-        ), "Hints must be provided for metadata user proxy"
-        assert (
-            magentic_ui_config.answer is not None
-        ), "Answer must be provided for metadata user proxy"
+        assert magentic_ui_config.task is not None, (
+            "Task must be provided for metadata user proxy"
+        )
+        assert magentic_ui_config.hints is not None, (
+            "Hints must be provided for metadata user proxy"
+        )
+        assert magentic_ui_config.answer is not None, (
+            "Answer must be provided for metadata user proxy"
+        )
         user_proxy = MetadataUserProxy(
             name="user_proxy",
             description="Metadata User Proxy Agent",

--- a/tests/test_url_status_manager.py
+++ b/tests/test_url_status_manager.py
@@ -46,3 +46,38 @@ async def test_url_status_manager():
     assert not url_status_manager.is_url_allowed("sample.com")
     assert not url_status_manager.is_url_allowed("sample.com/foo")
     assert not url_status_manager.is_url_allowed("sample.com/bar")
+
+
+@pytest.mark.asyncio
+async def test_explicit_block_list():
+    url_status_manager = UrlStatusManager(
+        url_statuses=None,
+        explicit_block_list=["blocked.com/private"],
+    )
+
+    assert url_status_manager.is_url_blocked("blocked.com/private/page")
+    assert not url_status_manager.is_url_allowed("blocked.com/private/page")
+
+
+@pytest.mark.asyncio
+async def test_url_match_with_query_and_fragment():
+    url_statuses = {
+        "example.com/path;param=value?foo=bar#frag": URL_ALLOWED,
+    }
+    url_status_manager = UrlStatusManager(url_statuses=url_statuses)
+
+    assert url_status_manager.is_url_allowed(
+        "https://example.com/path;param=value?foo=bar#frag"
+    )
+    assert not url_status_manager.is_url_allowed(
+        "https://example.com/path;param=value?foo=bar#other"
+    )
+    assert not url_status_manager.is_url_allowed(
+        "https://example.com/path;param=other?foo=bar#frag"
+    )
+
+
+@pytest.mark.asyncio
+async def test_url_block_list_alias():
+    manager = UrlStatusManager(url_statuses=None, url_block_list=["alias.com"])
+    assert manager.is_url_blocked("alias.com/page")


### PR DESCRIPTION
## Summary
- add explicit block list to WebSurfer configuration
- adjust call sites to use alias `url_block_list`
- silence pyright warning in teammanager file
- tests cover explicit blocking and URL matching options

## Testing
- `ruff check src`
- `pyright src` *(fails with existing type errors)*
- `PYTHONPATH=src pytest tests/test_url_status_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6840902d9508832a9efc099a5642eb48