### PR TITLE
Fix message ordering in approval guard

### DIFF
--- a/src/magentic_ui/approval_guard.py
+++ b/src/magentic_ui/approval_guard.py
@@ -228,7 +228,8 @@ class ApprovalGuard(BaseApprovalGuard):
             if len(selected_context) > 5:
                 selected_context = selected_context[-5:]
 
-            request_messages = [system_message]
+            # preserve order: system message followed by historical context
+            request_messages = [system_message] + selected_context
 
             result = await self.model_client.create(request_messages)
 


### PR DESCRIPTION
## Summary
- ensure `selected_context` is included when checking if a tool requires approval
- keep context order after the system message

## Testing
- `uv sync`
- `.venv/bin/poe check` *(fails: Browser.close: Connection closed while reading from the driver)*

------
https://chatgpt.com/codex/tasks/task_e_6840920a906c832ab57f06c50396c3ef