### PR TITLE
Fix scroll calculations for page navigation

### DIFF
--- a/src/magentic_ui/tools/playwright/playwright_controller.py
+++ b/src/magentic_ui/tools/playwright/playwright_controller.py
@@ -510,7 +510,7 @@ class PlaywrightController:
 
             # Move cursor with the scroll using gradual animation
             x, y = self.last_cursor_position
-            new_y = max(0, min(y - scroll_amount, self.viewport_height))
+            new_y = max(0, min(y + scroll_amount, self.viewport_height))
             await self._animation.gradual_cursor_animation(page, x, y, x, new_y)
         else:
             # Regular instant scroll
@@ -538,7 +538,7 @@ class PlaywrightController:
 
             # Move cursor with the scroll using gradual animation
             x, y = self.last_cursor_position
-            new_y = max(0, min(y + scroll_amount, self.viewport_height))
+            new_y = max(0, min(y - scroll_amount, self.viewport_height))
             await self._animation.gradual_cursor_animation(page, x, y, x, new_y)
         else:
             # Regular instant scroll


### PR DESCRIPTION
## Summary
- correct cursor update for `page_down`
- correct cursor update for `page_up`

## Testing
- `poe check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840920c8d30832aa08b7e7a2b67f7f3